### PR TITLE
Add tag commands

### DIFF
--- a/commands/tag/create.js
+++ b/commands/tag/create.js
@@ -1,0 +1,21 @@
+module.exports = message => {
+	if(message.args.length < 3) return message.reply(`Not enough parameters. Syntax: ${message.prefix}tag create <tag-name> <tag-content>`);
+	if(message.args[1].length > 30) return message.reply("Tag name must not reach 30 characters.");
+	if(!/[\w\-]{3,16}/.test(message.args[1])) return message.reply("Tag name is invalid. Make sure it matches with this regular expression: ```js\n[\\w\\-]{3,16}\n```");
+	const { connection } = message;
+	connection.prepare("SELECT * FROM tags WHERE name=?").then(prepared => {
+		prepared.get([ message.args[1] ]).then(res => {
+			if(res) {
+				message.reply("A tag with that name already exists.");
+			} else {
+				connection.prepare("INSERT INTO tags VALUES (?, ?, ?, ?, ?)").then(prepared2 => {
+					prepared2.run([ message.args[1], message.author.id, message.args.slice(2).join(" "), Date.now(), 0 ]).then(() => {
+						message.reply(`Your tag has been created. You can access it by typing ${message.prefix}tag ${message.args[1]}`, {
+							disableEveryone: true
+						});
+					});
+				});
+			}
+		});
+	});
+}

--- a/commands/tag/delete.js
+++ b/commands/tag/delete.js
@@ -1,0 +1,13 @@
+module.exports = message => {
+	if(message.args.length < 2) return message.reply(`Not enough parameters. Syntax: ${message.prefix}tag delete <tag-name>`); 
+	const { connection } = message;
+	connection.prepare("DELETE FROM tags WHERE name=? AND author=?").then(prepared => {
+		prepared.run([message.args[1], message.author.id]).then(res => {
+			if(res.changes === 0) {
+				message.reply("The tag was not found or you don't own that tag.");
+			} else {
+				message.reply("Tag has been deleted.");
+			}
+		});
+	}).catch(console.log);
+}

--- a/commands/tag/list.js
+++ b/commands/tag/list.js
@@ -1,0 +1,18 @@
+module.exports = message => {
+	const { connection } = message;
+	let limit, timestamp = Date.now();
+	if(!isNaN(message.args[1]) && message.args[1] < 10) limit = parseInt(message.args[1]);
+	else limit = 10;
+	connection.all(`SELECT * FROM tags ORDER BY uses DESC LIMIT ${limit}`).then(res => {
+		message.channel.send({ embed: {
+			title: "Tag list",
+			description: `A list of ${limit} tags has been loaded in ${Date.now() - timestamp} milliseconds. To view a tag, type \`${message.prefix}tag <tagname>\``,
+			fields: res.map(element => {
+				return {
+					name: element.name,
+					value: `Uses: ${element.uses} | Created at ${new Date(parseInt(element.createdAt)).toLocaleString()}`
+				};
+			})
+		}});
+	}).catch(console.log);
+}

--- a/commands/tag/transfer.js
+++ b/commands/tag/transfer.js
@@ -1,0 +1,29 @@
+module.exports = async message => {
+	// Command deactivated for now
+	// People could create disturbing tags
+	// And transfer them to others 
+	// So that it looks like they created it.
+	return message.reply("This command is not available for now.");
+	if(message.args.length < 3) return message.reply(`Not enough parameters. Syntax: ${message.prefix}tag transfer <tag-name> <new-owner>`);
+	let target;
+	try {
+		target = await message.client.fetchUser(message.args[2]);
+	} catch(error) {
+		return message.reply("User not found. Make sure to provide a **User ID**.");
+	}
+	if(!target) return message.reply("User not found. Make sure to provide a **User ID**!");
+	const { connection } = message;
+	connection.prepare("UPDATE tags SET author=? WHERE author=? AND name=?").then(prepared => {
+		prepared.run([ message.args[2], message.author.id, message.args[1] ]).then(res => {
+			if(res.changes === 0) {
+				message.reply("Tag could not be transfered.");
+			} else {
+				message.channel.send(target.toString(), { embed: {
+					title: "Tag transfer",
+					description: `__${message.author.tag}__ wants to transfer the tag *${message.args[1]}* to you. \nWrite **y**es to accept it or **n**o to decline it.`
+				}});
+				
+			}
+		});
+	});
+}

--- a/commands/tag/view.js
+++ b/commands/tag/view.js
@@ -1,0 +1,16 @@
+module.exports = message => {
+    if (message.args.length != 2) return message.reply("Please specify a tag by its name.");
+    const { readdirSync } = require("fs");
+    const { connection } = message;
+    connection.prepare("SELECT * FROM tags WHERE name=?").then(prepared => {
+        prepared.get([message.args[1]]).then(res => {
+            if (!res) return message.reply("Tag was not found");
+            connection.prepare("UPDATE tags SET uses=? WHERE name=?").then(prepared2 => {
+                prepared2.run([res.uses + 1, message.args[1]]);
+            });
+            message.channel.send(res.content.substr(0, 1900) + "\n\n__Tag owner (ID):__ " + res.author, {
+                disableEveryone: true
+            });
+        });
+    }).catch(console.log);
+}


### PR DESCRIPTION
## Additions
- Tag/Create (https://github.com/y21/wiiset-bot/pull/2/commits/e00f0cdf8eb3a8efd00645b3c916fd7761cfd0d2)
- Tag/Delete (https://github.com/y21/wiiset-bot/pull/2/commits/06ef360f65039deb5b55425f4046c4725b66d898)
- Tag/List (https://github.com/y21/wiiset-bot/pull/2/commits/e5882c831779ad4ca4b207238f8e7206aad3cf18)
- Tag/Transfer (deactivated) (https://github.com/y21/wiiset-bot/pull/2/commits/cf2486c8336041d620293ddb6742e45d8aff64d5)
- Tag/View (https://github.com/y21/wiiset-bot/pull/2/commits/ac1eecba378433437e6b7455ffb2232440b1d691)

## Changes
- none

## Deletions
- none

## Notes
The command `tag/transfer` is deactivated for now because (quoting from file comments) "People could create disturbing tags and transfer them to others so that it looks like they created it.