### PR TITLE
change: send direct image links instead of attachments

### DIFF
--- a/commands/Cat.ts
+++ b/commands/Cat.ts
@@ -13,7 +13,7 @@ export default <Command>{
     run: (base: Base, message: any) => {
         return new Promise((a: any, b: any) => {
             fetch("http://aws.random.cat/meow").then(v => v.json()).then((res: any) => {
-                a([new Attachment(res.file, "cat.jpg")]);
+                a([res.file]);
             }).catch((err: any) => {
                 b(err);
             })

--- a/commands/Dog.ts
+++ b/commands/Dog.ts
@@ -13,7 +13,7 @@ export default <Command>{
     run: (base: Base, message: any) => {
         return new Promise((a: any, b: any) => {
             fetch("https://dog.ceo/api/breeds/image/random").then(v => v.json()).then((res: any) => {
-                a([new Attachment(res.message, "dog.jpg")]);
+                a([res.message]);
             }).catch((err: any) => {
                 b(err);
             })


### PR DESCRIPTION
Before this PR, w.cat and w.dog would send an attachment which shows a picture of a cat/dog. This caused the server to reach 9% of the bandwidth limit within 2 days. To reduce traffic, I have decided to send direct links to images since they still embed.